### PR TITLE
Fix Error [ERR_MODULE_NOT_FOUND]

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,7 @@
       "es6"
     ],
     "module": "commonjs",
-    "outDir": "./dist",
+    "outDir": "./",
     "rootDir": "./",
     "removeComments": true,
     "downlevelIteration": true,


### PR DESCRIPTION
Hi @p-mcgowan and thanks for the rebuild.

At present, if one installs the package with `npm i @p-mcgowan/minimist`, the `index.js` and `index.d.ts` files are downloaded into a `/dist` subfolder, causing the import to fail: `Error [ERR_MODULE_NOT_FOUND]: Cannot find package '(...)/node_modules/@p-mcgowan/minimist/' imported from (...)`.

This is fixed by ensuring the `index.js` and `index.d.ts` files are present in the module main `/` folder.